### PR TITLE
Add PowerShell Script.

### DIFF
--- a/getdgraph.ps1
+++ b/getdgraph.ps1
@@ -1,0 +1,313 @@
+#!/usr/bin/env pwsh
+# ##############################################################################
+#
+#                  Dgraph Installer Script for Windows
+#
+#   Homepage: https://dgraph.io
+#   Requires: Powershell
+#
+# Hello! This is a script that installs Dgraph
+# into your PATH (which may require to run as Administrator).
+# Use it like this:
+#
+#	$ iwr https://get.dgraph.io/install.ps1 -useb | iex
+#
+# This should work on windows.
+# ##############################################################################
+
+param(
+	[uri]$base_server_uri = "https://dgraph.io", #origin_uri
+	[uri]$URL = "https://get.dgraph.io/latest",
+	[uri]$TAGsURI = "https://api.github.com/repos/dgraph-io/dgraph/releases/tags",
+	[string]$checksum_file = "dgraph-checksum-windows-amd64.sha256",
+	[uri]$releasesURI = "https://github.com/dgraph-io/dgraph/releases/download",
+	[switch]$IsRunAsAdmin = $false,
+	$ErrorActionPreference = "Stop",
+	[string]$Agree = "N",
+	[string]$setPath = "C:\",
+	$TEMPpath = "$env:TEMP",
+	[string]$dgraphIO = "dgraph-io",
+	[string]$Version = $Version,
+	[string]$acceptLicense = $acceptLicense,
+	$ProgressPreference
+)
+
+# Disable Invoke-WebRequest progress bar to speed up download due to bug
+$ProgressPreference = "SilentlyContinue"
+
+# GitHub requires TLS 1.2 - This is here for the sake of concern.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$currentAdm = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+$currentAdm = $currentAdm.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+$latest_release = Invoke-WebRequest $URL -UseBasicParsing | ConvertFrom-Json | Select-Object -Expand tag_name
+$ROOTPath = "$setPath$dgraphIO"
+$ExecPolicy = (Get-ExecutionPolicy)
+
+function Invoke-Elevated ($scriptblock) {
+	$_Pwsh = "$psHome\powershell.exe"
+	if (-not (Test-Path -LiteralPath "$psHome\powershell.exe")) {
+		$_Pwsh = "pwsh"
+	}
+	if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]"Administrator")) {
+		Start-Process "$_Pwsh" -Verb runAs -ArgumentList $scriptblock
+	}
+}
+
+function Expand-Tar ($tarFile, $dest) {
+	tar -xvzf $tarFile -C $dest
+}
+function Write-Good {
+	param($Message,
+		[ValidateSet("Progress", "Information")]
+		[string]$Type = "Progress")
+
+	[System.ConsoleColor]$color = [System.ConsoleColor]::Green
+	switch ($Type) {
+		"Information" {
+			$color = [System.ConsoleColor]::Gray
+		}
+	}
+
+	Write-Host -Object "INFO: $Message" -ForegroundColor $color
+}
+
+function Write-Error {
+	param($Message,
+		[ValidateSet("Progress", "Information")]
+		[string]$Type = "Progress")
+
+	[System.ConsoleColor]$color = [System.ConsoleColor]::Red
+	switch ($Type) {
+		"Information" {
+			$color = [System.ConsoleColor]::Gray
+		}
+	}
+
+	Write-Host -Object "ERROR: $Message" -ForegroundColor $color
+}
+
+if ($ExecPolicy -ne "RemoteSigned") {
+	Write-Error "This script needs to be executed with ExecutionPolicy set as RemoteSigned"
+	Write-Error "please run (as Administrator):"
+	Write-Error 'Set-ExecutionPolicy -ExecutionPolicy "RemoteSigned"'
+	Write-Error "After run the script you can set it to `"-ExecutionPolicy Undefined`""
+	return
+}
+
+if ((Test-Path -LiteralPath "$ROOTPath\dgraph.exe") -and !($Version)) {
+	Write-Good "You already have Dgraph $Version installed."
+	#!TODO Without Checksum I can't check the version easily.
+	Write-Good "Please, if you wanna updgrade to $selectVersion use the version variable."
+	$Version = "" #cleanup variable
+	break
+} elseif (-not (Test-Path -LiteralPath "$ROOTPath")) {
+	Write-Good "Creating install path"
+	New-Item -Force -Path "$setPath" -Name "$dgraphIO" -ItemType "directory"
+}
+
+###############################################################################
+# Pre-steps - Define the Version
+###############################################################################
+
+if ($Version) {
+	$global:selectVersion = $Version
+	Write-Good "Version manually set: $Version"
+	$Version = "" #cleanup variable
+} else {
+	$global:selectVersion = $latest_release
+}
+
+function Get-RGDitDetails {
+	$RAW_CVer = REG QUERY "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v ProductName |
+	ConvertTo-Json | ConvertFrom-Json
+
+	$RAW_RLID =REG QUERY "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v ReleaseId |
+	ConvertTo-Json | ConvertFrom-Json
+	
+	$RAW_OS = $RAW_CVer[2].Replace("REG_EXPAND_SZ","").Replace("REG_SZ","").Replace("ProductName","").replace('  ' , '')
+	$RAW_RLID = $RAW_RLID[2].Replace("REG_EXPAND_SZ","").Replace("REG_SZ","").Replace("ReleaseId","").replace('  ' , '')
+
+	return @"
+INFO: :: OS: $RAW_OS
+INFO: :: Build: $RAW_RLID
+"@
+}
+
+function Get-License () {
+	curl.exe -s https://raw.githubusercontent.com/dgraph-io/dgraph/master/licenses/DCL.txt
+
+	$content = @"
+
+By downloading Dgraph you agree to the Dgraph Community License (DCL) terms
+shown above. An open source (Apache 2.0) version of Dgraph without any
+DCL-licensed enterprise features is available by building from the Dgraph
+source code. See the source installation instructions for more info:
+
+https://github.com/dgraph-io/dgraph#install-from-source
+
+"@
+	return $content
+}
+
+function Get-Agree () {
+	param(
+		$Agree
+	)
+	if ($Agree -match "[yY]([eE][sS])?") {
+		$script:Agree = "Y"
+		Write-Good "Dgraph Community License terms accepted with -y/--accept-license option."
+	} else {
+		$script:Agree = "NO"
+	}
+}
+function check_license_agreement () {
+	Get-License
+
+	# Feels like powershell doesn't work well with copy paste ASCII art. So, let's use this instead. 
+	Invoke-RestMethod https://artii.herokuapp.com/make?text=Dgraph
+
+	Write-Host $dg_
+
+	$Agree = Read-Host -Prompt "Do you agree to the terms of the Dgraph Community License? [Y/n]"
+	Write-Host "You have signed '$Agree'"
+	Get-Agree -Agree $Agree
+
+}
+function check_if_exists {
+	try {
+		$response = Invoke-WebRequest -Uri "$TAGsURI/$selectVersion" -UseBasicParsing -ErrorAction:Stop -TimeoutSec 180
+		$StatusCode = $Response.StatusCode
+	} catch {
+		$StatusCode = $_.Exception.Response.StatusCode.value__
+		Write-Error "INTERNAL :: HTTP Status Code $StatusCode"
+		Write-Error "This version doesn't exist or it is a typo (Tip: You need to add 'v' eg: v20.0.1-rc1)"
+		break
+	}
+	if ($Response) {
+		$toCompare = $Response | ConvertFrom-Json | Select-Object -Expand tag_name
+		if ($toCompare -eq $latest_release) {
+			Write-Good "Downloading latest release: $latest_release"
+		}
+		if ($toCompare -notmatch $latest_release) {
+			Write-Good "Latest Dgraph is $latest_release"
+			Write-Good "The version you choose to download is $toCompare Downloading..."
+		}
+	}
+
+}
+
+function Get-Raw-Env-Path () {
+	$RAW_ = REG QUERY "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v Path |
+	Select-String "Path" |
+	ConvertTo-Json |
+	ConvertFrom-Json  |
+	Select-Object -Expand line
+	
+	$RAW = $RAW_.Replace("REG_EXPAND_SZ","").Replace("REG_SZ","").Replace("Path","").replace('  ' , '').split(";") | ConvertTo-Json |	ConvertFrom-Json
+	
+	$OutPut=""
+	$count=0
+
+	foreach ($key in $RAW) {
+		if(($key) -and ($count -ne 0)) { $OutPut += ";$key" } else { $OutPut += "$key"}
+		$count+=1
+	  }
+
+	return $OutPut
+}
+
+function Create-Script () {
+	$content = @"
+#!/usr/bin/env pwsh
+SETX PATH /M "$RawEnvPath;;$ROOTPath"
+"@
+
+   Set-Content "$ROOTPath\setEnv.ps1" $content -en ASCII
+
+}
+
+###############################################################################
+# Step - license
+###############################################################################
+
+if ($acceptLicense) { 
+	Get-Agree -Agree $acceptLicense
+	$acceptLicense = "" #cleanup variable
+} else {
+	check_license_agreement
+	$acceptLicense = "" #cleanup variable
+} 
+
+if ($Agree -eq "NO") {
+	Write-Error "You must agree to the license terms to install Dgraph."
+	Write-Error "Installation failed. Please try again."
+	Write-Host "Press any key to continue..."
+	$Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyUp") > $null
+	return
+}
+###############################################################################
+# Step - Check if the version exists
+###############################################################################
+
+check_if_exists
+
+###############################################################################
+# Step - Checksum
+###############################################################################
+#!TODO NEED the hash from windows builds. That's wasn't found.
+
+# $checksum_link = "$releasesURI/$selectVersion/$checksum_file"
+
+# Write-Output "Downloading checksum file for $selectVersion build."
+
+# Write-Output "checksum_link $checksum_link build."
+
+# Invoke-WebRequest -Uri $checksum_link -OutFile $ROOTPath\$checksum_file -UseBasicParsing
+
+# $dgraphBinHash = Get-FileHash C:\dgraph-io\dgraph.exe | select -expand Hash
+
+# Write-Good "dgraphBinHash = ====> $dgraphBinHash"
+
+###############################################################################
+# Step - Prepare the install and download Dgraph 
+###############################################################################
+
+# Is good to have this log - Users can send us error logs and we gonna know what OS they are running it.
+Write-Host -ForegroundColor Green  (Get-RGDitDetails)
+
+Write-Good "Downloading Dgraph wait..."
+
+$dgraph_link = "$releasesURI/$selectVersion/dgraph-windows-amd64.tar.gz"
+
+Invoke-WebRequest -Uri $dgraph_link -OutFile "$ROOTPath\dgraph-windows-amd64.tar.gz" -UseBasicParsing
+
+Write-Good "Extracting..."
+
+Expand-Tar "$ROOTPath\dgraph-windows-amd64.tar.gz" "$ROOTPath\"
+
+Write-Good "Installing"
+
+$RawEnvPath = Get-Raw-Env-Path
+$HasDgraphEnv = $RawEnvPath -Match "dgraph-io"
+
+if ($currentAdm -and !($HasDgraphEnv)) {
+	SETX PATH /M "$RawEnvPath;$ROOTPath"
+} elseif(!($currentAdm) -and !($HasDgraphEnv)) {
+	Create-Script
+	Invoke-Elevated  "$ROOTPath\setEnv.ps1"
+}
+
+$env:Path += ";$ROOTPath\" # This isnt permanent, just to make dgraph available right away.
+
+
+###############################################################################
+#cleanup variables and TMP
+###############################################################################
+
+$Version = ""
+# Remove-Item -Path  "C:\dgraph-io" -Force -Recurse UNISTALL
+
+Write-Good "All done, cheers!"
+Write-Output "Dgraph was successfully installed"
+Write-Output "Open a new terminal and run 'dgraph --help' to get started"

--- a/readme.md
+++ b/readme.md
@@ -35,10 +35,30 @@ curl https://get.dgraph.io -sSf | bash
 
 ### Using Powershell
 
+This script needs to be executed with ExecutionPolicy set as RemoteSigned"
+please run (as Administrator):"
+
+```
+Set-ExecutionPolicy -ExecutionPolicy "RemoteSigned"
+```
+
+After run the script you can set it to `-ExecutionPolicy "Undefined"`
+
 From `https://get.dgraph.io/windows`:
 ```shell
- # Todo
+iwr https://get.dgraph.io/windows -useb | iex
 ```
+
+Download the script and run locally
+```shell
+iwr http://get.dgraph.io/windows -useb -outf install.ps1; .\install.ps1
+```
+
+## Environment Variables
+
+`$Version="v20.03.1"`: Choose Dgraph’s version manually (default: The latest stable release).
+
+`$acceptLicense="yes"`: Choose Dgraph’s version manually (default: The latest stable release, you can do tag combinations e.g v2.0.0-beta1 or -rc1).
 
 # Compatibility
 


### PR DESCRIPTION
With this Script, users who use Windows 10 or any Windows Server with PowerShell will be able to install Dgraph at `C:\dgraph-io`. And it will run "globally". Which means, users can start Dgraph from anywhere in any windows terminal.

```
# Install Latest
> iwr https://get.dgraph.io/windows -useb | iex

# Install a predefined version via variable.
> $Version="v20.03.1"; iwr http://get.dgraph.io/windows -useb | iex

# Install a predefined version and accept license via variable.
> $Version="v20.03.1"; $acceptLicense="yes" ; iwr http://get.dgraph.io/windows -useb | iex

# Install a predefined version adn accept the license via flag args.
> iwr http://get.dgraph.io/windows -useb -outf install.ps1; .\install.ps1 -version v20.03.1 -acceptLicense yes
```

BTW, `TAR` and `CURL` are part of the Windows platform since 2017.  Which means we don't need to verify its existence.
