### PR TITLE
Fix escape code printfs in install script. (#330)

### DIFF
--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -30,19 +30,19 @@ sudo_cmd=""
 argVersion=
 
 print_instruction() {
-    printf "$WHITE$1$RESET\n"
+    printf '%b\n' "$WHITE$1$RESET"
 }
 
 print_step() {
-    printf "$BLACK$1$RESET\n"
+    printf '%b\n' "$BLACK$1$RESET"
 }
 
 print_error() {
-    printf "$RED$1$RESET\n"
+    printf '%b\n' "$RED$1$RESET"
 }
 
 print_good() {
-    printf "$GREEN$1$RESET\n"
+    printf '%b\n' "$GREEN$1$RESET"
 }
 
 check_license_agreement() {
@@ -67,7 +67,7 @@ EOF
 
 install_dgraph() {
 
-printf $BLACK
+printf "%b" "$BLACK"
 cat << "EOF"
   _____                        _
  |  __ \                      | |
@@ -79,7 +79,7 @@ cat << "EOF"
          |___/          |_|
 
 EOF
-printf $RESET
+printf "%b" "$RESET"
 
 	install_path="/usr/local/bin"
 

--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -15,11 +15,11 @@
 
 set -e
 
-BLACK='\033[30;1m'
+DIM='\033[2m'
+BOLD='\033[1m'
 RED='\033[91;1m'
 GREEN='\033[32;1m'
 RESET='\033[0m'
-WHITE='\033[97;1m'
 
 acceptLower=`echo "$ACCEPT_LICENSE" | dd  conv=lcase 2> /dev/null`
 systemdLower=`echo "$INSTALL_IN_SYSTEMD" | dd  conv=lcase 2> /dev/null`
@@ -30,11 +30,11 @@ sudo_cmd=""
 argVersion=
 
 print_instruction() {
-    printf '%b\n' "$WHITE$1$RESET"
+    printf '%b\n' "$BOLD$1$RESET"
 }
 
 print_step() {
-    printf '%b\n' "$BLACK$1$RESET"
+    printf '%b\n' "$DIM$1$RESET"
 }
 
 print_error() {
@@ -67,7 +67,7 @@ EOF
 
 install_dgraph() {
 
-printf "%b" "$BLACK"
+printf "%b" "$BOLD"
 cat << "EOF"
   _____                        _
  |  __ \                      | |


### PR DESCRIPTION
    \033[30;1mDownload complete.\033[0m
    \033[30;1mComparing checksums for dgraph binaries\033[0m
    \033[32;1mYou already have Dgraph v20.03.3 installed.\033[0m

This change fixes the above output to show escape codes:

    Download complete.
    Comparing checksums for dgraph binaries
    You already have Dgraph v20.03.3 installed.

This is done by changing the printf escape code to `%b`. See the bash man page:

    printf [-v var] format [arguments]
           ...
           %b     causes printf to expand backslash escape sequences in the corresponding argument in the same way
                  as echo -e.

Also, replace the black and white text colors with dim and bold text so that the text is still readable on terminals with black or white backgrounds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/14)
<!-- Reviewable:end -->
