### PR TITLE
fix(github-release): Set the latest release version explicitly.

### DIFF
--- a/scripts/github-release.sh
+++ b/scripts/github-release.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+LATEST_RELEASE="v20.07.0"
+
 update_latest_release() {
   response=$(curl --write-out "%{http_code}" --silent --output /tmp/latest-release.txt \
-  https://api.github.com/repos/dgraph-io/dgraph/releases/latest)
+  https://api.github.com/repos/dgraph-io/dgraph/releases/tags/$LATEST_RELEASE)
 
   if [ "$response" == "200" ]; then
     mv /tmp/latest-release.txt latest-release.txt


### PR DESCRIPTION
GitHub release's "latest" version always points to the latest tag,
which isn't necessarily the latest Dgraph release. For example, we can
release v1.2.x, but v20.07.x is still the latest release series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/15)
<!-- Reviewable:end -->
