### PR TITLE
add a deno script for latest-release based on CalVer

### DIFF
--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -5,6 +5,7 @@ let token: string = '';
 interface githubRepoTags {
     nodes: Node[];
     totalCount: number;
+    tag_name: string;
 }
 
 interface Node {
@@ -29,6 +30,7 @@ let list: githubRepoTags = {
             "tagName": "v0.3"
         }
     ],
+    "tag_name": "0",
     "totalCount": 0
 };
 
@@ -83,8 +85,9 @@ const update_latest_release = async (token : string) => {
         let latestBeta = data.filter(e => e.tagName.match(Be))
         let latestRC = data.filter(e => e.tagName.match(RC))
         let latestCalVer = data.filter(e => (e.tagName.match(CalVer) && !e.tagName.match(RC)) && !e.tagName.match(Be))
+        let tag_name = latestCalVer[0].tagName;
 
-        writeJson("./latest-release.txt", {latestBeta, latestRC, latestCalVer});
+        writeJson("./latest-release.txt", {latestBeta, latestRC, latestCalVer, tag_name });
     } catch (error) {
         throw error;
     }

--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -1,4 +1,4 @@
-import {exists, writeJson} from "https://deno.land/std@0.63.0/fs/mod.ts";
+import {exists, writeJson} from "https://deno.land/std@0.51.0/fs/mod.ts";
 import {exec} from 'https://cdn.depjs.com/exec/mod.ts'
 
 let token: string = '';

--- a/scripts/github-release.ts
+++ b/scripts/github-release.ts
@@ -1,0 +1,100 @@
+import {exists, writeJson} from "https://deno.land/std@0.63.0/fs/mod.ts";
+
+let token: string = '';
+
+interface githubRepoTags {
+    nodes: Node[];
+    totalCount: number;
+}
+
+interface Node {
+    tagName: string;
+}
+
+if (import.meta.main) {
+    let TK = /--token/g;
+    let getToke = Deno.args.filter(e => e.match(TK))
+    if (getToke.length === 1) {
+        token = getToke[0] ?. replace("--token", "").replace("=", "")
+    }
+    if (getToke.length === 0) {
+        console.error("Provide a token")
+        throw "exit";
+    }
+}
+
+let list: githubRepoTags = {
+    "nodes": [
+        {
+            "tagName": "v0.3"
+        }
+    ],
+    "totalCount": 0
+};
+
+let query = `query {
+    repository(owner:"dgraph-io", name:"dgraph") {
+     releases (first:100, orderBy: { field: CREATED_AT, direction: DESC }){
+      nodes{
+        tagName
+      }
+      totalCount
+    }
+    }
+}
+`
+
+const callGithub = async (token : string) => {
+    function handleErrors(res: any) {
+        if (! res.ok) {
+            console.error("Got error from Github API")
+            throw res.status;
+        }
+        return res;
+    }
+    await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify(
+            {query: `${query}`}
+        )
+    }).then(handleErrors).then(res => res.json()).then(res => list = res.data.repository.releases)
+}
+
+const update_latest_release = async (token : string) => {
+    try {
+        var dt = new Date();
+
+        console.log(`${
+            dt.toJSON()
+        } Getting latest release information from Github.`)
+
+        await callGithub(token)
+
+        let data = list.nodes.sort((a, b) => b.tagName.localeCompare(a.tagName));
+
+        let Be = /beta/g;
+        let RC = /-rc/g;
+        let CalVer = /v20./g;
+
+        let latestBeta = data.filter(e => e.tagName.match(Be))
+        let latestRC = data.filter(e => e.tagName.match(RC))
+        let latestCalVer = data.filter(e => (e.tagName.match(CalVer) && !e.tagName.match(RC)) && !e.tagName.match(Be))
+
+        writeJson("./latest-release.txt", {latestBeta, latestRC, latestCalVer});
+    } catch (error) {
+        throw error;
+    }
+}
+
+const sleep = (ms : any) => {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+while (true) {
+    update_latest_release(token);
+    await sleep(120000);
+}


### PR DESCRIPTION
This script creates an object with latestBeta, latestRC, latestCalVer, and tag_name.

The CalVer in the right order.

## Testing this Script

1. install Deno curl -fsSL https://deno.land/x/install/install.sh | sh
2. Get the raw script address e.g https://raw.githubusercontent.com/dgraph-io/Install-Dgraph/1084961ea6b9cc63f536b5e9b0f0969d056c3be8/scripts/github-release.ts
3. Create a GitHub token
4. run anywhere on you computer
 `deno run --allow-read --allow-net --unstable --allow-write ${raw_script_address.ts} --token=${GitHub_token}`

You can see it running at https://get.dgraph.io/latestbeta

The tag `"tag_name": "v20.07.0"` is the latest of all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/16)
<!-- Reviewable:end -->
