### PR TITLE
Fix(getdgraph.sh): Fix typo in install script.

### DIFF
--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -207,7 +207,7 @@ printf "%b" "$RESET"
 
 		# Backup existing dgraph binaries in HOME directory
 		if hash dgraph 2>/dev/null; then
-			dgraph_path="$(command -v, dgraph)"
+			dgraph_path="$(command -v dgraph)"
 			dgraph_backup="dgraph_backup_olderversion"
 			print_step "Backing up older versions in ~/$dgraph_backup (password may be required)."
 			mkdir -p ~/$dgraph_backup


### PR DESCRIPTION
There was an extra comma in the `command` call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/26)
<!-- Reviewable:end -->
