### PR TITLE
Add option to Download the binary to the current path.

### DIFF
--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -127,7 +127,7 @@ printf "%b" "$RESET"
 			if [ "$release_version" == "$toCompare" ]; then
 			    return
 				else
-				print_error "This version doesn't exist or it is a typo (Tip: You need to add \"v\" eg: v2.0.0-rc1)"
+				print_error "This version doesn't exist or it is a typo (Tip: You need to add \"v\" eg: v22.0.0-RC1-20221003)"
 				exit 1
 			fi
 	}
@@ -353,7 +353,7 @@ verify_system() {
 
 print_usage() {
 	echo "Usage:"
-	echo "	-v='' | --version='v20.07.2'	: Choose Dgraph's version manually."
+	echo "	-v='' | --version='v22.0.0' 	: Choose Dgraph's version manually."
 	echo "	-d    | --download             	: Download the binary to the current path."
 	echo "	-s    | --systemd             	: Install Dgraph as a service."
 	echo "	-y    | --accept-license	    : Automatically agree to the terms of the Dgraph Community License."

--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -97,23 +97,23 @@ printf "%b" "$RESET"
 	fi
 
 	if [ "$JUST_DOWNLOAD" = "y" ]; then
-		install_path="./"
-	else
+		install_path="."
+	  else
 
-	install_path="/usr/local/bin"
+	  install_path="/usr/local/bin"
 
-	# Check sudo permissions
-	if hash sudo 2>/dev/null; then
+	  # Check sudo permissions
+	  if hash sudo 2>/dev/null; then
 		sudo_cmd="sudo"
 		echo "Requires sudo permission to install Dgraph binaries to $install_path."
 		if ! $sudo_cmd -v; then
 			print_error "Need sudo privileges to complete installation."
 			exit 1;
 		fi
-	fi
+	  fi
 		# Create /usr/local/bin directory if it doesn't exist.
 		$sudo_cmd mkdir -p $install_path
-fi
+    fi
 
 
 	if ! check_license_agreement; then
@@ -172,7 +172,7 @@ fi
 		exit 1;
 	fi
 
-	dgraph=$(grep -m 1 $install_path/dgraph  /tmp/"$checksum_file" | grep -E -o '[a-zA-Z0-9]{64}')
+	dgraph=$(grep -m 1 "$install_path"/dgraph  /tmp/"$checksum_file" | grep -E -o '[a-zA-Z0-9]{64}')
 
 	if [ "$dgraph" == "" ]; then
 	     print_error "Sorry, we don't have binaries for this platform. Please build from source."
@@ -213,6 +213,12 @@ fi
 			exit 1;
 		fi
 
+        
+	if [ "$JUST_DOWNLOAD" = "y" ]; then
+		print_instruction "----------------------------- Dgraph -----------------------------------"
+		print_instruction "Downloading badger and dgraph locally only. Please move the binaries to your desired location."
+		print_instruction "----------------------------- Dgraph -----------------------------------"
+    	else
 		# Backup existing dgraph binaries in HOME directory
 		if hash dgraph 2>/dev/null; then
 			dgraph_path="$(command -v dgraph)"
@@ -221,8 +227,9 @@ fi
 			mkdir -p ~/$dgraph_backup
 			$sudo_cmd mv $dgraph_path* ~/$dgraph_backup/.
 		fi
-
-		$sudo_cmd mv "$temp_dir"/* $install_path/.
+    fi
+        
+		$sudo_cmd mv "$temp_dir"/* $install_path/
 		rm "/tmp/""$tar_file";
 		rm -rf "$temp_dir"
 

--- a/readme.md
+++ b/readme.md
@@ -45,14 +45,18 @@ Add `-s --` before the flags.
 
 >`-y | --accept-license`: Automatically agree to the terms of the Dgraph Community License (default: “n”).
 
+>`-d | --download`: Download Dgraph's binary to the current path only. No globally installation. (default: “n”).
+
 >`-s | --systemd`: Automatically create Dgraph’s installation as Systemd services (default: “n”).
 
->`-v | --version`: Choose Dgraph’s version manually (default: The latest stable release, you can do tag combinations e.g v20.03.1-beta1 or -rc1).
+>`-v | --version`: Choose Dgraph’s version manually (default: The latest stable release, you can do tag combinations e.g v22.0.0-RC1-20221003 or -rc2).
 
 
 ## Environment Variables
 
 >`ACCEPT_LICENSE`: Automatically agree to the terms of the Dgraph Community License (default: “n”).
+
+>`JUST_DOWNLOAD`: Download Dgraph's binary to the current path only. No globally installation. (default: “n”).
 
 >`INSTALL_IN_SYSTEMD`: Automatically create Dgraph’s installation as Systemd services (default: “n”).
 
@@ -85,7 +89,7 @@ iwr https://get.dgraph.io/windows -useb | iex
 With Environment Variables:
 
 ```shell
-$Version="v20.03.1"; $acceptLicense="yes"; iwr http://get.dgraph.io/windows -useb | iex
+$Version="v22.00.1"; $acceptLicense="yes"; iwr http://get.dgraph.io/windows -useb | iex
 ```
 
 Download the script and run locally
@@ -97,7 +101,7 @@ iwr http://get.dgraph.io/windows -useb -outf install.ps1; .\install.ps1
 Run locally with flags
 
 ```shell
-iwr http://get.dgraph.io/windows -useb -outf install.ps1; .\install.ps1 -version v20.03.1 -acceptLicense yes
+iwr http://get.dgraph.io/windows -useb -outf install.ps1; .\install.ps1 -version v22.00.1 -acceptLicense yes
 ```
 
 ## Flags
@@ -110,7 +114,7 @@ iwr http://get.dgraph.io/windows -useb -outf install.ps1; .\install.ps1 -version
 
 >`$Version="v20.03.1"`: Choose Dgraph’s version manually (default: The latest stable release).
 
->`$acceptLicense="yes"`: Choose Dgraph’s version manually (default: The latest stable release, you can do tag combinations e.g v2.0.0-beta1 or -rc1).
+>`$acceptLicense="yes"`: Choose Dgraph’s version manually (default: The latest stable release, you can do tag combinations e.g v22.0.0-RC1-20221003 or -rc2).
 
 ## Compatibility
 


### PR DESCRIPTION
Add convenient option to download Dgraph binaries in the current path.

If you don't want to install Dgraph globally, you can just run it in the context of the current path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/30)
<!-- Reviewable:end -->
