### PR TITLE
Add new trap to throw the line

### DIFF
--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -13,7 +13,8 @@
 #
 # This should work on Mac, Linux, and BSD systems.
 
-set -e
+set -eE
+set -o functrace
 
 DIM='\033[2m'
 BOLD='\033[1m'
@@ -382,7 +383,15 @@ if  [[  -z $REGX  &&  "$platform" == "darwin" ]]; then
 	fi
 }
 
+failure() {
+  local lineno=$1
+  local msg=$2
+  print_error "Failed at $lineno: $msg"
+}
+
+trap 'failure ${LINENO} "$BASH_COMMAND" ${exit_error}' ERR
 trap exit_error EXIT
+
 for f in "$@"; do
 	case $f in
 		'-y'|'--accept-license')


### PR DESCRIPTION
This will throw

```command
Failed at 176: dgraph=$(...)
There was some problem while installing Dgraph. Please share the output of this script with us on https://discuss.dgraph.io so that we can resolve the issue for you.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/32)
<!-- Reviewable:end -->
