### PR TITLE
chore(script): Remove hardcoded cache

### DIFF
--- a/getdgraph.sh
+++ b/getdgraph.sh
@@ -311,7 +311,7 @@ setup_systemD() {
 	gen "dgraph.io Alpha instance" \
 		"Requires=dgraph-zero.service" \
 		"" \
-		"dgraph alpha --lru_mb 2048 -p /var/lib/dgraph/p -w /var/lib/dgraph/w" \
+		"dgraph alpha -p /var/lib/dgraph/p -w /var/lib/dgraph/w" \
 		"dgraph-zero.service" \
 		$systemdPath/dgraph-alpha.service
 


### PR DESCRIPTION
The --lru_mb was renamed, but it is not needed. Dgraph can handle the size of RAM needed for cache.

fix #35

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/install-dgraph/36)
<!-- Reviewable:end -->
